### PR TITLE
update xref label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "q2doc"
 authors = [
     { name = "Evan Bolyen", email = "developers@qiime2.org" }
 ]
-description = "Generate MystMD documentation from a qiime2 plugin"
+description = "Generate MystMD documentation from a qiime2 deployment."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 dynamic = ["version"]

--- a/q2doc/directives/describe_action.py
+++ b/q2doc/directives/describe_action.py
@@ -40,7 +40,7 @@ class DescribeAction(DirectiveHandler):
         if (util.is_primitive_type(qiime_type)
                 or util.is_visualization_type(qiime_type)
                 or util.is_collection_type(qiime_type)):
-            url = f'xref:qiime2#qiime2.plugin.{qiime_type.name}'
+            url = f'xref:q2doc-api-target#qiime2.plugin.{qiime_type.name}'
             ast.append(md.link_ast(md.inline_code_ast(qiime_type.name), url))
 
             if qiime_type.fields:
@@ -60,7 +60,7 @@ class DescribeAction(DirectiveHandler):
                 return [md.inline_code_ast(str(qiime_type))]
 
         if qiime_type.predicate:
-            url = f'xref:qiime2#qiime2.plugin.{qiime_type.predicate.name}'
+            url = f'xref:q2doc-api-target#qiime2.plugin.{qiime_type.predicate.name}'
             ast.append(md.inline_code_ast(' % '))
             ast.append(md.link_ast(md.inline_code_ast(str(qiime_type.predicate.name)), url))
             ast.append(md.inline_code_ast(str(qiime_type.predicate)[len(qiime_type.predicate.name):]))


### PR DESCRIPTION
@ebolyen, we discussed this a couple of weeks ago - basically, add a more unique label for the *Developing with QIIME 2* xref. I also tried to come up with a pattern that would be less likely to overlap with other labels - I've started using the pattern: `_<label>-ext`, but happy to go with something else if you prefer. And just let me know if I'm missing other places where this needs to change. 

We'll need to update a few other repos that also reference DWQ2 when we make this change, but better now than when we have more. Otherwise I believe these will have broken xrefs on their next builds. Here are the ones I know of:
- [x] [genome-sampler](https://github.com/caporaso-lab/genome-sampler/blob/48f92d95ed614e45186b09d802b3f3c7da451eec/docs/myst.yml#L11) - https://github.com/caporaso-lab/genome-sampler/pull/116
- [x] [amplicon-docs](https://github.com/qiime2/amplicon-docs/blob/main/docs/myst.yml#L12) - https://github.com/qiime2/amplicon-docs/pull/12
- [x] [gut-to-soil](https://github.com/caporaso-lab/gut-to-soil-tutorial/blob/main/docs/myst.yml#L12) - https://github.com/caporaso-lab/gut-to-soil-tutorial/pull/7
- [x] [q2-fmt](https://github.com/qiime2/q2-fmt/blob/dev/book/q2_fmt_book/myst.yml#L9) - https://github.com/qiime2/q2-fmt/pull/126