### PR TITLE
BUG: fix describe-usage identification on nodes

### DIFF
--- a/q2doc/transforms/transform_usage.py
+++ b/q2doc/transforms/transform_usage.py
@@ -8,7 +8,12 @@ import q2doc.myst as md
 is_preview = os.getenv('Q2DOC_PREVIEW') is not None
 
 def is_usage(node):
-    return node.get('data', {}).get('source') == 'describe-usage'
+    data = node.get('data', {})
+    if not isinstance(data, dict):
+        # Jupyter notebook outputs or other custom directives
+        return False
+    else:
+        return data.get('source') == 'describe-usage'
 
 AUTO_COLLECT = 4
 


### PR DESCRIPTION
Discovered by @misialq.

Nodes such as:
```json
{
    "type": "block",
    "kind": "notebook-code",
    "children": [
        {
            "type": "code",
            "executable": true,
            "value": "[parsl]\n\n[[parsl.executors]]\nclass = \"HighThroughputExecutor\"\nlabel = \"default\"\n\n[parsl.executors.provider]\nclass = \"LocalProvider\"\nmax_blocks = 5",
            "key": "F62v3DG4zk"
        },
        {
            "type": "output",
            "id": "47vrbObxY48UnFhe2jHxi",
            "data": [],
            "key": "IKu3ve7WK3"
        }
    ],
    "key": "Qb5Sg3Wp2Z"
}
```

will set "data" but with a payload we didn't anticipate (but probably should have).

