### PR TITLE
NEW: adds :hide: to describe-usage

### DIFF
--- a/q2doc/directives/describe_usage.py
+++ b/q2doc/directives/describe_usage.py
@@ -18,11 +18,15 @@ class DescribeUsage(DirectiveHandler):
             'scope': dict(
                 type='string',
                 help='A directory where results will be saved. Will be treated as a unique namespace'
+            ),
+            'hide': dict(
+                type='boolean',
+                help='Evaluate the directive, but hide it from the final output.'
             )
         }
 
     @classmethod
-    def apply_options(cls, ast, node, scope=None):
+    def apply_options(cls, ast, node, scope=None, hide=False):
         ast = md.code_ast('python', node['value'])
-        ast['data'] = dict(deferred=True, scope=scope, source='describe-usage')
+        ast['data'] = dict(deferred=True, scope=scope, hide=hide, source='describe-usage')
         return [ast]

--- a/q2doc/transforms/transform_usage.py
+++ b/q2doc/transforms/transform_usage.py
@@ -45,7 +45,10 @@ class TransformUsage(Transform):
 
         try:
             from q2doc.drivers.galaxy import MystGalaxyUsage
-            drivers.append(dict(name='[Galaxy]', sync='galaxy', driver=MystGalaxyUsage(self.scope)))
+            # HACK: galaxy has to execute certain imports to further inspect them.
+            # so remove galaxy if is_preview is true
+            if not is_preview:
+                drivers.append(dict(name='[Galaxy]', sync='galaxy', driver=MystGalaxyUsage(self.scope)))
         except ModuleNotFoundError:
             pass
 
@@ -72,9 +75,11 @@ class TransformUsage(Transform):
     def run(self, ast):
         coroutine = ast_walk(ast)
         node = None
+        failure = False
         while node := coroutine.send(node):
             if is_usage(node):
                 source = node['value']
+                hide = node['data'].get('hide', False)
                 tabs = []
                 try:
                     exec_driver, drivers = self.setup_scope(node)
@@ -91,6 +96,7 @@ class TransformUsage(Transform):
                         tabs.append(md.tabitem_ast(rendered, interface['name'],
                                                    sync=interface['sync']))
                 except Exception:
+                    failure = True
                     result = [md.code_ast('python', traceback.format_exc())]
 
 
@@ -99,6 +105,9 @@ class TransformUsage(Transform):
                     md.tabitem_ast(node, '[View Source]', sync='raw')
                 )
 
-                node = md.block_ast([tabset, *result])
+                if hide and not failure:
+                    node = md.block_ast([])
+                else:
+                    node = md.block_ast([tabset, *result])
 
         return ast


### PR DESCRIPTION
Use as:

```
:::{describe-usage}
:scope: moving-pictures
:hide:

sample_metadata = use.init_metadata_from_url(
   'sample-metadata',
   'https://data.qiime2.org/2025.4/tutorials/moving-pictures/sample_metadata.tsv')
:::
````

This will cause the directive to execute for the enabled usage drivers, but will not display the results.

This can be used to hide initializations because the data comes from external sources or previous tutorials where the context is obvious.