### PR TITLE
IMP: make doc builds with rendering errors fail by default

### DIFF
--- a/q2doc/transforms/transform_usage.py
+++ b/q2doc/transforms/transform_usage.py
@@ -98,7 +98,7 @@ class TransformUsage(Transform):
                                                    sync=interface['sync']))
                 except Exception:
                     if not ignore_errors:
-                        raise Exception
+                        raise
 
                     failure = True
                     result = [md.code_ast('python', traceback.format_exc())]

--- a/q2doc/transforms/transform_usage.py
+++ b/q2doc/transforms/transform_usage.py
@@ -6,6 +6,7 @@ import q2doc.myst as md
 
 
 is_preview = os.getenv('Q2DOC_PREVIEW') is not None
+ignore_errors = os.getenv('Q2DOC_IGNORE_ERRORS') is not None
 
 def is_usage(node):
     data = node.get('data', {})
@@ -96,6 +97,9 @@ class TransformUsage(Transform):
                         tabs.append(md.tabitem_ast(rendered, interface['name'],
                                                    sync=interface['sync']))
                 except Exception:
+                    if not ignore_errors:
+                        raise Exception
+
                     failure = True
                     result = [md.code_ast('python', traceback.format_exc())]
 


### PR DESCRIPTION
This is in response to a recent issue we experienced where the interface of an action in `q2-dada2` was changed but tutorials that use that action were not updated to stay in sync. The docs were re-rendered and only days later was it noticed that the published tutorials had tracebacks in place of download links. 

This change will make such doc builds themselves fail by raising the underlying rendering error in the build process. A new `Q2DOC_IGNORE_ERRORS` environment variable can be used when the old behavior is desired. 